### PR TITLE
Fix name

### DIFF
--- a/Config/config.json
+++ b/Config/config.json
@@ -1,6 +1,6 @@
 {
     "name": "MineWeb",
-    "slug": "Mineweb",
+    "slug": "MineWeb",
     "author": "Eywek",
     "version": "1.2.2",
     "apiID": 1,


### PR DESCRIPTION
Le nom n'étant pas valide, celui-ci à était modifié pour assuré le bon fonctionnement du thème sur le CMS.